### PR TITLE
Update SIP password field

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -29,7 +29,7 @@ class SIPAccount(BaseModel):
     register_addr: str
     register_port: str
     register_user: str
-    register_pswd: str
+    register_password: str
     register_ttl: str
     enable_reg: str
 
@@ -115,7 +115,7 @@ def extract_sip_account(config: str) -> SIPAccount:
         register_addr=g("Register Addr").group(1).strip() if g("Register Addr") else "",
         register_port=g("Register Port").group(1).strip() if g("Register Port") else "",
         register_user=g("Register User").group(1).strip() if g("Register User") else "",
-        register_pswd=g("Register Pswd").group(1).strip() if g("Register Pswd") else "",
+        register_password=g("Register Password").group(1).strip() if g("Register Password") else "",
         register_ttl=g("Register TTL").group(1).strip() if g("Register TTL") else "",
         enable_reg=g("Enable Reg").group(1).strip() if g("Enable Reg") else ""
     )
@@ -137,7 +137,7 @@ SIP1 Display Name     :{sip.display_name}
 SIP1 Register Addr    :{sip.register_addr}
 SIP1 Register Port    :{sip.register_port}
 SIP1 Register User    :{sip.register_user}
-SIP1 Register Pswd    :{sip.register_pswd}
+SIP1 Register Password:{sip.register_password}
 SIP1 Register TTL     :{sip.register_ttl}
 SIP1 Enable Reg       :{sip.enable_reg}
 <<END OF FILE>>"""

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -51,7 +51,7 @@ export default function FanvilConfigForm() {
       {selected && (
         <>
           <h2 className="text-xl font-semibold">Настройки SIP1</h2>
-          {["phone_number", "display_name", "register_addr", "register_port", "register_user", "register_pswd", "register_ttl", "enable_reg"].map(f => (
+          {["phone_number", "display_name", "register_addr", "register_port", "register_user", "register_password", "register_ttl", "enable_reg"].map(f => (
             <input key={f} value={sip[f] || ""} onChange={e => updateSip(f, e.target.value)} placeholder={f.replace("_", " ")} className="border p-2 w-full mb-2" />
           ))}
 


### PR DESCRIPTION
## Summary
- rename `register_pswd` field to `register_password`
- use new config key `Register Password` when parsing and formatting configs
- update frontend list of SIP fields

## Testing
- `python -m py_compile backend/main.py`
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840300893688322a614ea1004f265aa